### PR TITLE
Fix #43, preventing pAIs from dragging mobs into disposals.

### DIFF
--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -141,7 +141,10 @@
 // mouse drop another mob or self
 //
 /obj/machinery/disposal/MouseDrop_T(mob/target, mob/user)
-	if (!istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || user.stat || istype(user, /mob/living/silicon/ai))
+	if (!istype(target) || target.buckled || get_dist(user, src) > 1 || get_dist(user, target) > 1 || user.stat)
+		return
+	if (istype(user, /mob/living/silicon/ai) || istype(user, /mob/living/silicon/pai))
+		// Digital mobs shouldn't be able to drag people around
 		return
 	if(isanimal(user) && target != user) return //animals cannot put mobs other than themselves into disposal
 	src.add_fingerprint(user)


### PR DESCRIPTION
This fixes the disposal stuffing at least, but there might be more places a pAI can drag a player onto. Further hunting might be needed.
