### PR TITLE
Xeno Gibber Update

### DIFF
--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -82,6 +82,10 @@
 
 	..()
 
+/datum/species/xenos/handle_death(var/mob/living/carbon/human/H)
+	if(H.stomach_contents.len)
+		H.gib()
+
 /datum/species/xenos/handle_environment_special(var/mob/living/carbon/human/H)
 
 	var/turf/T = H.loc


### PR DESCRIPTION
Frees people who were swallowed by xenos by gibbing the xeno upon its death. 
