### PR TITLE
Xenomorph Hotfix #9000

### DIFF
--- a/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
+++ b/code/modules/mob/living/carbon/human/species/xenomorphs/alien_species.dm
@@ -133,7 +133,7 @@
 					H << "<span class='alium'>You feel something mend itself inside your [E.display_name].</span>"
 			return 1
 
-	if(!H.reagents.has_reagent("nutriment"))	//Getting food speeds it up
+	if(!H.reagents.has_reagent("nutriment"))
 		H.reagents.add_reagent("nutriment", 1)
 	if(!H.reagents.has_reagent("iron"))
 		H.reagents.add_reagent("iron", 1)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -148,7 +148,7 @@ Please contact me on #coderbus IRC. ~Carn x
 	overlays.Cut()
 
 	//Hacky pre-empting of this whacky icon stuff
-	if(lying && species.name_plural == "Xenomorphs" && stat != DEAD)
+	if(lying && species.name_plural == "Xenomorphs" && stat != DEAD && resting)
 		icon = src.species.icobase
 		icon_state = src.species.prone_icon
 		return


### PR DESCRIPTION
- Xenomorphs only use their resting sprite when resting.
