### PR TITLE
Valens ship on it's own shuttle controller

### DIFF
--- a/code/controllers/shuttle_controller.dm
+++ b/code/controllers/shuttle_controller.dm
@@ -245,6 +245,28 @@ var/global/datum/shuttle_controller/shuttle_controller
 	MS.warmup_time = 0
 	shuttles["Mercenary"] = MS
 
+// Valen's shuttle - same layout as nuke and goes to mostly same locations
+	var/datum/shuttle/multi_shuttle/VALS = new/datum/shuttle/multi_shuttle()
+	VALS.origin = locate(/area/adminprep/valansship)
+
+	VALS.destinations = list(
+		"Northwest of the station" = locate(/area/syndicate_station/northwest),
+		"North of the station" = locate(/area/syndicate_station/north),
+		"Northeast of the station" = locate(/area/syndicate_station/northeast),
+		"Southwest of the station" = locate(/area/syndicate_station/southwest),
+		"South of the station" = locate(/area/syndicate_station/south),
+		"Southeast of the station" = locate(/area/syndicate_station/southeast),
+		"Telecomms Satellite" = locate(/area/syndicate_station/commssat),
+		"Mining Asteroid" = locate(/area/syndicate_station/mining),
+		)
+
+	VALS.announcer = "NSV Icarus"
+	VALS.arrival_message = "Attention, Apollo, you have a large signature approaching the station - looks unarmed to surface scans. We're too far out to intercept - brace for visitors."
+	VALS.departure_message = "Your visitors are on their way out of the system, Apollo, burning delta-v like it's nothing. Good riddance."
+	VALS.interim = locate(/area/syndicate_station/transit)
+
+	VALS.warmup_time = 0
+	shuttles["Valans"] = VALS
 
 //This is called by gameticker after all the machines and radio frequencies have been properly initialized
 /datum/shuttle_controller/proc/setup_shuttle_docks()

--- a/maps/z-admin-shuttle.dmm
+++ b/maps/z-admin-shuttle.dmm
@@ -7,120 +7,103 @@
 "ag" = (/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 4},/obj/machinery/door/blast/shutters{density = 0; icon_state = "shutter0"; id = "syndieshutters"; name = "Blast Shutters"; opacity = 0},/turf/simulated/shuttle/plating,/area/adminprep/valansship)
 "ah" = (/turf/space,/turf/simulated/shuttle/wall{dir = 1; icon_state = "diagonalWall3"},/area/adminprep/valansship)
 "ai" = (/turf/simulated/shuttle/wall{icon_state = "wall3"},/area/adminprep/valansship)
-"aj" = (/obj/structure/table,/obj/machinery/recharger,/obj/machinery/recharger/wallcharger{pixel_x = -25},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"ak" = (/obj/structure/computerframe,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"al" = (/obj/machinery/computer/shuttle_control/multi/syndicate{req_access = list(103); req_access_txt = "0"},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"am" = (/obj/structure/table,/obj/machinery/door_control{id = "syndieshutters"; name = "remote shutter control"; req_access_txt = "103"},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"an" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/obj/structure/grille,/obj/machinery/door/blast/shutters{density = 0; icon_state = "shutter0"; id = "syndieshutters"; name = "Blast Shutters"; opacity = 0},/turf/simulated/shuttle/plating,/area/adminprep/valansship)
-"ao" = (/obj/structure/table,/obj/machinery/microwave{pixel_x = -1; pixel_y = 2},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"ap" = (/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aq" = (/obj/structure/stool/bed/chair{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"ar" = (/obj/structure/table,/obj/item/weapon/storage/box/donkpockets{pixel_x = 2; pixel_y = 3},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"as" = (/obj/structure/stool/bed/chair{dir = 4},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"at" = (/obj/structure/table,/obj/item/stack/sheet/glass{amount = 15},/obj/item/device/flashlight/lamp/green,/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000},/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000},/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"au" = (/obj/item/device/radio/intercom{name = "Station Intercom (General)"; pixel_y = -28},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"av" = (/obj/structure/table,/obj/item/weapon/paper_bin{pixel_x = -3; pixel_y = 8},/obj/item/weapon/pen{pixel_y = 4},/obj/item/weapon/storage/toolbox/emergency,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aw" = (/turf/space,/turf/simulated/shuttle/wall{icon_state = "diagonalWall3"},/area/adminprep/valansship)
-"ax" = (/obj/machinery/door/airlock/diamond{req_access_txt = "103"},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"ay" = (/turf/space,/turf/simulated/shuttle/wall{dir = 4; icon_state = "diagonalWall3"},/area/adminprep/valansship)
-"az" = (/obj/structure/closet/secure_closet/medical_wall{pixel_x = -32; pixel_y = 0; req_access = null; req_access_txt = "103"},/obj/item/stack/medical/splint,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aA" = (/obj/item/device/radio/intercom{name = "Station Intercom (General)"; pixel_y = 22},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aB" = (/obj/structure/closet/hydrant{pixel_y = 32},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aC" = (/obj/item/weapon/storage/secure/safe{pixel_x = 5; pixel_y = 29},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aD" = (/obj/structure/sign/poster{poster_type = "/datum/poster/bay_50"; pixel_x = -32},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aE" = (/obj/structure/toilet{dir = 4},/obj/structure/mirror{dir = 4; pixel_x = -32; pixel_y = 0},/turf/simulated/shuttle/floor{icon_state = "floor7"},/area/adminprep/valansship)
-"aF" = (/turf/simulated/shuttle/floor{icon_state = "floor7"},/area/adminprep/valansship)
-"aG" = (/obj/structure/bookcase{name = "bookcase (Adult)"},/turf/simulated/shuttle/floor{icon_state = "floor7"},/area/adminprep/valansship)
-"aH" = (/obj/machinery/atmospherics/pipe/tank/air{dir = 4; start_pressure = 740.5},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aI" = (/obj/machinery/atmospherics/pipe/simple/visible{dir = 4},/turf/simulated/shuttle/wall{icon_state = "wall3"},/area/adminprep/valansship)
-"aJ" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 8; frequency = 1380; id_tag = "synd_pump"},/obj/machinery/embedded_controller/radio/airlock/airlock_controller{frequency = 1380; id_tag = "synd_airlock"; pixel_x = 0; pixel_y = 25; req_access_txt = "103"; tag_airpump = "synd_pump"; tag_chamber_sensor = "synd_sensor"; tag_exterior_door = "synd_outer"; tag_interior_door = "synd_inner"},/obj/machinery/airlock_sensor{frequency = 1380; id_tag = "synd_sensor"; pixel_x = -25; pixel_y = 0},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aK" = (/obj/machinery/door/airlock/external{frequency = 1380; icon_state = "door_closed"; id_tag = "synd_outer"; locked = 0; name = "Ship External Access"; req_access = null; req_access_txt = "103"},/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valansship)
-"aL" = (/obj/effect/decal/cleanable/vomit,/turf/simulated/shuttle/floor{icon_state = "floor7"},/area/adminprep/valansship)
-"aM" = (/obj/item/weapon/cigbutt,/turf/simulated/shuttle/floor{icon_state = "floor7"},/area/adminprep/valansship)
-"aN" = (/obj/structure/stool,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aO" = (/obj/structure/table,/obj/item/weapon/paper_bin{pixel_x = -3; pixel_y = 8},/obj/item/weapon/pen{pixel_y = 4},/obj/item/weapon/folder/white,/obj/item/device/flashlight/lamp/green,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aP" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/turf/simulated/shuttle/plating,/area/adminprep/valansship)
-"aQ" = (/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 8},/turf/simulated/shuttle/plating,/area/adminprep/valansship)
-"aR" = (/obj/machinery/door/window{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aS" = (/obj/structure/stool/bed/chair/comfy/black,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aT" = (/obj/structure/filingcabinet,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aU" = (/obj/machinery/door/airlock/external{frequency = 1380; icon_state = "door_closed"; id_tag = "synd_inner"; locked = 0; name = "Ship External Access"; req_access = null; req_access_txt = "0"},/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valansship)
-"aV" = (/obj/structure/reagent_dispensers/beerkeg,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aW" = (/obj/structure/stool/bed/chair/comfy/black{dir = 4},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aX" = (/obj/structure/table/woodentable,/obj/item/ashtray/glass,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aY" = (/obj/structure/stool/bed/chair/comfy/black{dir = 8},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"aZ" = (/obj/machinery/access_button{command = "cycle_interior"; frequency = 1380; master_tag = "synd_airlock"; name = "interior access button"; pixel_x = 25; pixel_y = 0; req_access_txt = "0"},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"ba" = (/obj/structure/table,/obj/machinery/chem_dispenser/beer,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"bb" = (/obj/structure/table/woodentable,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/obj/item/weapon/reagent_containers/food/drinks/drinkingglass,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"bc" = (/obj/structure/stool/bed/chair/comfy/black{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"bd" = (/obj/structure/table,/obj/machinery/chem_dispenser/soda,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"be" = (/obj/structure/table/woodentable,/obj/item/weapon/reagent_containers/glass/rag,/obj/item/weapon/reagent_containers/food/drinks/shaker,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"bf" = (/obj/structure/coatrack,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"bg" = (/obj/structure/bookcase{name = "bookcase (Reference)"},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"bh" = (/obj/structure/bookcase{name = "bookcase (Fiction)"},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"bi" = (/obj/machinery/sleeper,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bj" = (/obj/machinery/sleep_console,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bk" = (/obj/machinery/portable_atmospherics/canister/oxygen,/obj/structure/sign/nosmoking_1{pixel_y = 32},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bl" = (/obj/structure/table,/obj/item/roller{pixel_y = 8},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bm" = (/obj/structure/table,/obj/structure/closet/secure_closet/medical_wall{pixel_y = 32; req_access = null; req_access_txt = "103"},/obj/item/bodybag,/obj/item/weapon/reagent_containers/syringe/antiviral,/obj/item/weapon/reagent_containers/syringe/antiviral,/obj/item/weapon/reagent_containers/syringe/antiviral,/obj/item/weapon/reagent_containers/glass/bottle/antitoxin{pixel_x = -4; pixel_y = 8},/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline{pixel_x = 4; pixel_y = 7},/obj/item/weapon/reagent_containers/syringe,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bn" = (/obj/structure/closet/hydrant{pixel_y = 32},/obj/item/weapon/storage/toolbox/mechanical,/obj/item/clothing/glasses/welding,/obj/item/weapon/twohanded/fireaxe,/obj/item/stack/sheet/plasteel{amount = 50},/obj/item/stack/sheet/metal{amount = 50},/obj/item/stack/sheet/glass{amount = 50},/obj/item/stack/rods{amount = 50},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"bo" = (/obj/machinery/door/blast/regular{id = "syndieshutters_telebay"; name = "Outer Airlock"},/turf/simulated/shuttle/plating,/area/adminprep/valansship)
-"bp" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 4},/obj/structure/grille,/obj/machinery/door/blast/shutters{density = 0; dir = 8; icon_state = "shutter0"; id = "syndieshutters_infirmary"; name = "Blast Shutters"; opacity = 0},/turf/simulated/shuttle/plating,/area/adminprep/valansship)
-"bq" = (/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"br" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 4},/obj/structure/grille,/obj/machinery/door/blast/shutters{density = 0; dir = 8; icon_state = "shutter0"; id = "syndieshutters_infirmary"; name = "Blast Shutters"; opacity = 0},/turf/simulated/shuttle/plating,/area/adminprep/valansship)
-"bs" = (/obj/machinery/bodyscanner,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bt" = (/obj/machinery/body_scanconsole,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bu" = (/obj/machinery/door/window,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bv" = (/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 4},/obj/structure/grille,/obj/machinery/door/blast/shutters{density = 0; dir = 8; icon_state = "shutter0"; id = "syndieshutters_infirmary"; name = "Blast Shutters"; opacity = 0},/turf/simulated/shuttle/plating,/area/adminprep/valansship)
-"bw" = (/obj/structure/closet/emcloset,/obj/item/clothing/suit/space,/obj/item/clothing/mask/breath,/obj/item/weapon/tank/emergency_oxygen/engi,/obj/item/clothing/head/helmet/space,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"bx" = (/obj/machinery/door_control{id = "syndieshutters_infirmary"; name = "remote shutter control"; pixel_x = -25; req_access_txt = "0"},/obj/structure/mopbucket,/obj/item/weapon/mop,/obj/item/weapon/reagent_containers/glass/bucket,/obj/structure/closet,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"by" = (/obj/item/device/radio/intercom{dir = 4; name = "Station Intercom (General)"; pixel_x = 30},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bz" = (/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 8},/turf/simulated/shuttle/plating,/area/adminprep/valansship)
-"bA" = (/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/plating,/area/adminprep/valansship)
-"bB" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/table,/obj/item/weapon/bonesetter,/obj/item/weapon/bonegel,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bC" = (/obj/machinery/door/window{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bD" = (/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bE" = (/obj/structure/table,/obj/structure/window/reinforced{dir = 8},/obj/item/weapon/storage/firstaid/toxin{pixel_x = 3; pixel_y = 3},/obj/item/weapon/storage/firstaid/adv{pixel_x = 1},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bF" = (/obj/structure/table,/obj/item/weapon/storage/firstaid/o2{pixel_x = 3; pixel_y = 3},/obj/item/weapon/storage/firstaid/fire{pixel_x = 1},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bG" = (/obj/structure/sign/securearea{name = "\improper CAUTION"; pixel_x = 32},/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,/obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill,/obj/item/mecha_parts/mecha_equipment/tool/extinguisher,/obj/machinery/door_control{desc = "A remote control-switch for the cargo bay doors."; id = "syndieshutters_telebay"; name = "Cargo Bay control"; pixel_x = 0; pixel_y = 25; req_access_txt = "103"},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"bH" = (/obj/structure/table,/obj/item/weapon/scalpel,/obj/item/weapon/circular_saw{pixel_y = 8},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bI" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 11; pixel_y = 0},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bJ" = (/obj/structure/closet/secure_closet/medical_wall{pixel_y = 0; req_access = null; req_access_txt = "103"},/obj/item/weapon/surgicaldrill,/obj/item/clothing/gloves/latex,/obj/item/clothing/mask/surgical,/obj/item/weapon/reagent_containers/glass/bottle/stoxin,/obj/item/weapon/reagent_containers/glass/bottle/stoxin,/obj/item/weapon/reagent_containers/syringe,/turf/simulated/shuttle/wall{icon_state = "wall3"},/area/adminprep/valansship)
-"bK" = (/obj/mecha/medical/odysseus/loaded,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"bL" = (/obj/mecha/working/ripley/firefighter,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
-"bM" = (/obj/machinery/door/airlock/diamond{req_access_txt = "103"},/turf/simulated/floor/plating/airless,/area/adminprep/valansship)
-"bN" = (/obj/structure/table,/obj/item/weapon/cautery,/obj/item/weapon/hemostat,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bO" = (/obj/machinery/optable,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bP" = (/obj/structure/table,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/weapon/retractor,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
-"bQ" = (/obj/structure/shuttle/engine/heater,/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/plating/airless,/area/adminprep/valansship)
-"bR" = (/obj/machinery/door/airlock/external,/turf/simulated/floor/plating/airless,/area/adminprep/valansship)
-"bS" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion_l"},/turf/space,/area/adminprep/valansship)
-"bT" = (/obj/structure/shuttle/engine/propulsion,/turf/space,/area/adminprep/valansship)
-"bU" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion_r"},/turf/space,/area/adminprep/valansship)
-"bV" = (/obj/structure/table,/obj/item/weapon/airlock_electronics,/obj/item/weapon/airlock_electronics,/obj/item/weapon/airlock_electronics,/obj/item/weapon/storage/belt/utility/full,/obj/item/weapon/cell/infinite,/obj/item/weapon/cell/infinite,/obj/item/weapon/cell/infinite,/obj/item/stack/cable_coil/yellow,/obj/item/stack/rods{amount = 50},/obj/item/stack/sheet/glass{amount = 50},/obj/item/stack/sheet/metal{amount = 50},/obj/item/device/radio/headset,/obj/item/device/radio/headset,/obj/item/device/radio/headset,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"bW" = (/obj/structure/table,/obj/item/rig_module/mounted,/obj/item/rig_module/mounted,/obj/item/rig_module/mounted,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"bX" = (/obj/item/device/megaphone,/obj/item/device/megaphone,/obj/item/device/megaphone,/obj/item/weapon/tank/emergency_oxygen/double,/obj/item/weapon/tank/emergency_oxygen/double,/obj/item/weapon/tank/emergency_oxygen/double,/obj/item/clothing/mask/gas,/obj/item/clothing/mask/gas,/obj/item/clothing/mask/gas,/obj/structure/table,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"bY" = (/obj/machinery/portable_atmospherics/canister/oxygen,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"bZ" = (/obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse,/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/explosive,/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg,/obj/item/mecha_parts/mecha_equipment/tool/passenger,/obj/item/mecha_parts/mecha_equipment/tool/rcd,/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"ca" = (/obj/mecha/working/hoverpod,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"cb" = (/obj/item/weapon/rig/ert/engineer{armor = list("melee" = 60, "bullet" = 60, "laser" = 60, "energy" = 60, "bomb" = 60, "bio" = 100, "rad" = 100); desc = "A Visitor suit."; name = "Visitor Suit"},/obj/structure/mirror{dir = 4; pixel_x = -32; pixel_y = 0},/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"cc" = (/obj/item/weapon/rig/ert/engineer{armor = list("melee" = 60, "bullet" = 60, "laser" = 60, "energy" = 60, "bomb" = 60, "bio" = 100, "rad" = 100); desc = "A Visitor suit."; name = "Visitor Suit"},/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"cd" = (/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"ce" = (/obj/mecha/combat/phazon,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"cf" = (/obj/item/clothing/glasses/sunglasses/sechud{name = "Visitor Visor"; pixel_y = 3},/obj/item/weapon/card/id/centcom{desc = "Visitors ID"; icon = 'icons/obj/vehicles.dmi'; icon_state = "keys"; name = "\improper Visitor. ID"},/obj/item/weapon/storage/belt/utility/full,/obj/item/clothing/under/color/black,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"cg" = (/obj/item/weapon/card/id/centcom{desc = "Visitors ID"; icon = 'icons/obj/vehicles.dmi'; icon_state = "keys"; name = "\improper Visitor. ID"},/obj/item/clothing/shoes/black,/obj/item/device/radio/headset,/obj/item/clothing/glasses/eyepatch/fluff/thysse_1,/obj/item/weapon/storage/backpack/satchel,/obj/item/clothing/under/det/slob,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"ch" = (/obj/machinery/light{dir = 8},/mob/living/carbon/human,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"ci" = (/mob/living/carbon/human,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"cj" = (/obj/machinery/light{dir = 4},/obj/machinery/power/fractal_reactor,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"ck" = (/obj/machinery/floodlight{in_use = 0; on = 1},/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"cl" = (/obj/structure/closet/cabinet,/obj/item/weapon/tank/oxygen,/obj/item/weapon/tank/oxygen,/obj/item/weapon/gun/launcher/pneumatic,/obj/item/weapon/gun/launcher/pneumatic,/obj/item/weapon/gun/launcher/crossbow,/obj/item/weapon/gun/launcher/crossbow,/obj/item/stack/rods{amount = 10},/obj/item/stack/rods{amount = 10},/obj/item/weapon/cell/high,/obj/item/weapon/cell/high,/obj/item/weapon/melee/energy/sword/pirate,/obj/item/weapon/melee/energy/sword/pirate,/obj/item/weapon/gun/projectile/pistol,/obj/item/ammo_magazine/c9mm,/obj/item/weapon/legcuffs/beartrap,/obj/item/weapon/legcuffs/beartrap,/obj/item/weapon/storage/box/handcuffs,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"cm" = (/obj/structure/stool/bed/chair/comfy/black{dir = 8},/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"cn" = (/obj/item/weapon/card/id/captains_spare,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"co" = (/obj/machinery/door/airlock/diamond{req_access_txt = "103"},/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"cp" = (/obj/machinery/artifact,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"cq" = (/obj/structure/table,/obj/item/weapon/implantcase/explosive,/obj/item/weapon/implantcase/tracking,/obj/item/weapon/implanter,/obj/item/weapon/implanter/explosive,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"cr" = (/obj/machinery/computer/card,/obj/machinery/light,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
-"cs" = (/obj/machinery/door/airlock/external,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"aj" = (/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"ak" = (/obj/structure/table,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"al" = (/obj/machinery/computer/shuttle_control/multi/syndicate{req_access = list(103); req_access_txt = "0"; shuttle_tag = "Valans"},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"am" = (/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/obj/structure/grille,/obj/machinery/door/blast/shutters{density = 0; icon_state = "shutter0"; id = "syndieshutters"; name = "Blast Shutters"; opacity = 0},/turf/simulated/shuttle/plating,/area/adminprep/valansship)
+"an" = (/obj/structure/table,/obj/machinery/microwave{pixel_x = -1; pixel_y = 2},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"ao" = (/obj/structure/stool/bed/chair{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"ap" = (/obj/structure/table,/obj/item/weapon/storage/box/donkpockets{pixel_x = 2; pixel_y = 3},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aq" = (/obj/structure/stool/bed/chair{dir = 4},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"ar" = (/obj/structure/computerframe,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"as" = (/obj/structure/table,/obj/item/device/flashlight/lamp/green,/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000},/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000},/obj/item/weapon/cell/high{charge = 100; maxcharge = 15000},/obj/machinery/recharger/wallcharger{pixel_x = -27; pixel_y = -3},/obj/machinery/door_control{id = "syndieshutters"; name = "remote shutter control"; pixel_y = -22; req_access_txt = "103"},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"at" = (/obj/item/device/radio/intercom{name = "Station Intercom (General)"; pixel_y = -28},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"au" = (/obj/structure/table,/obj/item/weapon/storage/toolbox/emergency,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"av" = (/turf/space,/turf/simulated/shuttle/wall{icon_state = "diagonalWall3"},/area/adminprep/valansship)
+"aw" = (/obj/machinery/door/airlock/diamond{req_access_txt = "103"},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"ax" = (/turf/space,/turf/simulated/shuttle/wall{dir = 4; icon_state = "diagonalWall3"},/area/adminprep/valansship)
+"ay" = (/obj/structure/closet/secure_closet/medical_wall{pixel_x = -32; pixel_y = 0; req_access = null; req_access_txt = "103"},/obj/item/stack/medical/splint,/obj/item/stack/medical/ointment,/obj/item/stack/medical/ointment,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/bruise_pack,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"az" = (/obj/item/device/radio/intercom{name = "Station Intercom (General)"; pixel_y = 22},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aA" = (/obj/structure/closet/hydrant{pixel_y = 32},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aB" = (/obj/item/weapon/storage/secure/safe{pixel_x = 5; pixel_y = 29},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aC" = (/obj/structure/sign/poster{poster_type = "/datum/poster/bay_50"; pixel_x = -32},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aD" = (/obj/structure/toilet{dir = 4},/obj/structure/mirror{dir = 4; pixel_x = -32; pixel_y = 0},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"aE" = (/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"aF" = (/obj/structure/bookcase{name = "bookcase (Adult)"},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"aG" = (/obj/machinery/atmospherics/pipe/tank/air{dir = 4; start_pressure = 740.5},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aH" = (/obj/machinery/atmospherics/pipe/simple/visible{dir = 4},/turf/simulated/shuttle/wall{icon_state = "wall3"},/area/adminprep/valansship)
+"aI" = (/obj/machinery/atmospherics/unary/vent_pump/high_volume{dir = 8; frequency = 1380; id_tag = "synd_pump"},/obj/machinery/embedded_controller/radio/airlock/airlock_controller{frequency = 1380; id_tag = "synd_airlock"; pixel_x = 0; pixel_y = 25; req_access_txt = "103"; tag_airpump = "synd_pump"; tag_chamber_sensor = "synd_sensor"; tag_exterior_door = "synd_outer"; tag_interior_door = "synd_inner"},/obj/machinery/airlock_sensor{frequency = 1380; id_tag = "synd_sensor"; pixel_x = -25; pixel_y = 0},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aJ" = (/obj/machinery/door/airlock/external{frequency = 1380; icon_state = "door_closed"; id_tag = "synd_outer"; locked = 0; name = "Ship External Access"; req_access = null; req_access_txt = "103"},/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valansship)
+"aK" = (/obj/structure/stool,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aL" = (/obj/structure/table,/obj/item/weapon/paper_bin{pixel_x = -3; pixel_y = 8},/obj/item/weapon/pen{pixel_y = 4},/obj/item/weapon/folder/white,/obj/item/device/flashlight/lamp/green,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aM" = (/obj/structure/grille,/obj/structure/window/reinforced{dir = 4},/obj/structure/window/reinforced{dir = 8},/turf/simulated/shuttle/plating,/area/adminprep/valansship)
+"aN" = (/obj/machinery/door/window{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aO" = (/obj/structure/stool/bed/chair/comfy/black,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aP" = (/obj/structure/filingcabinet,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aQ" = (/obj/machinery/door/airlock/external{frequency = 1380; icon_state = "door_closed"; id_tag = "synd_inner"; locked = 0; name = "Ship External Access"; req_access = null; req_access_txt = "0"},/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valansship)
+"aR" = (/obj/structure/reagent_dispensers/beerkeg,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aS" = (/obj/structure/stool/bed/chair/comfy/black{dir = 4},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aT" = (/obj/structure/table/woodentable,/obj/item/ashtray/glass,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aU" = (/obj/structure/stool/bed/chair/comfy/black{dir = 8},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aV" = (/obj/machinery/access_button{command = "cycle_interior"; frequency = 1380; master_tag = "synd_airlock"; name = "interior access button"; pixel_x = 25; pixel_y = 0; req_access_txt = "0"},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aW" = (/obj/structure/table,/obj/machinery/chem_dispenser/beer,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aX" = (/obj/structure/stool/bed/chair/comfy/black{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aY" = (/obj/structure/table,/obj/machinery/chem_dispenser/soda,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"aZ" = (/obj/structure/table/woodentable,/obj/item/weapon/reagent_containers/glass/rag,/obj/item/weapon/reagent_containers/food/drinks/shaker,/obj/item/weapon/storage/box/drinkingglasses,/obj/structure/closet/walllocker{pixel_y = -25},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"ba" = (/obj/structure/coatrack,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"bb" = (/obj/structure/bookcase{name = "bookcase (Reference)"},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"bc" = (/obj/machinery/sleeper,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bd" = (/obj/machinery/sleep_console,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"be" = (/obj/structure/sign/nosmoking_1{pixel_y = 32},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bf" = (/obj/structure/table,/obj/item/roller{pixel_y = 8},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bg" = (/obj/structure/table,/obj/structure/closet/secure_closet/medical_wall{pixel_y = 32; req_access = null; req_access_txt = "103"},/obj/item/bodybag,/obj/item/weapon/reagent_containers/syringe/antiviral,/obj/item/weapon/reagent_containers/syringe/antiviral,/obj/item/weapon/reagent_containers/syringe/antiviral,/obj/item/weapon/reagent_containers/glass/bottle/antitoxin{pixel_x = -4; pixel_y = 8},/obj/item/weapon/reagent_containers/glass/bottle/inaprovaline{pixel_x = 4; pixel_y = 7},/obj/item/weapon/reagent_containers/syringe,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bh" = (/obj/structure/closet/hydrant{pixel_y = 32},/obj/item/weapon/storage/toolbox/mechanical,/obj/item/clothing/glasses/welding,/obj/item/weapon/twohanded/fireaxe,/obj/item/stack/sheet/plasteel{amount = 50},/obj/item/stack/sheet/metal{amount = 50},/obj/item/stack/sheet/glass{amount = 50},/obj/item/stack/rods{amount = 50},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"bi" = (/obj/machinery/door/blast/regular{id = "syndieshutters_telebay"; name = "Outer Airlock"},/turf/simulated/shuttle/plating,/area/adminprep/valansship)
+"bj" = (/obj/structure/window/reinforced{dir = 8},/obj/structure/window/reinforced{dir = 4},/obj/structure/grille,/obj/machinery/door/blast/shutters{density = 0; dir = 8; icon_state = "shutter0"; id = "syndieshutters_infirmary"; name = "Blast Shutters"; opacity = 0},/turf/simulated/shuttle/plating,/area/adminprep/valansship)
+"bk" = (/obj/machinery/bodyscanner,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bl" = (/obj/machinery/body_scanconsole,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bm" = (/obj/machinery/door/window,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bn" = (/obj/machinery/portable_atmospherics/canister/oxygen,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"bo" = (/obj/machinery/door_control{id = "syndieshutters_infirmary"; name = "remote shutter control"; pixel_x = -25; req_access_txt = "0"},/obj/structure/mopbucket,/obj/item/weapon/mop,/obj/item/weapon/reagent_containers/glass/bucket,/obj/structure/closet,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bp" = (/obj/item/device/radio/intercom{dir = 4; name = "Station Intercom (General)"; pixel_x = 30},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bq" = (/obj/structure/closet/emcloset,/obj/item/clothing/suit/space,/obj/item/clothing/mask/breath,/obj/item/weapon/tank/emergency_oxygen/engi,/obj/item/clothing/head/helmet/space,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"br" = (/obj/structure/window/reinforced{dir = 1},/obj/structure/table,/obj/item/weapon/bonesetter,/obj/item/weapon/bonegel,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bs" = (/obj/machinery/door/window{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bt" = (/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bu" = (/obj/structure/table,/obj/structure/window/reinforced{dir = 8},/obj/item/weapon/storage/firstaid/toxin{pixel_x = 3; pixel_y = 3},/obj/item/weapon/storage/firstaid/adv{pixel_x = 1},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bv" = (/obj/structure/table,/obj/item/weapon/storage/firstaid/o2{pixel_x = 3; pixel_y = 3},/obj/item/weapon/storage/firstaid/fire{pixel_x = 1},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bw" = (/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/obj/structure/window/reinforced{dir = 8},/turf/simulated/shuttle/plating,/area/adminprep/valansship)
+"bx" = (/obj/structure/grille,/obj/structure/window/reinforced,/obj/structure/window/reinforced{dir = 1},/turf/simulated/shuttle/plating,/area/adminprep/valansship)
+"by" = (/obj/structure/table,/obj/item/weapon/scalpel,/obj/item/weapon/circular_saw{pixel_y = 8},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bz" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 11; pixel_y = 0},/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bA" = (/obj/structure/closet/secure_closet/medical_wall{pixel_y = 0; req_access = null; req_access_txt = "103"},/obj/item/weapon/surgicaldrill,/obj/item/clothing/gloves/latex,/obj/item/clothing/mask/surgical,/obj/item/weapon/reagent_containers/glass/bottle/stoxin,/obj/item/weapon/reagent_containers/glass/bottle/stoxin,/obj/item/weapon/reagent_containers/syringe,/turf/simulated/shuttle/wall{icon_state = "wall3"},/area/adminprep/valansship)
+"bB" = (/obj/structure/sign/securearea{name = "\improper CAUTION"; pixel_x = 32},/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,/obj/item/mecha_parts/mecha_equipment/tool/drill/diamonddrill,/obj/item/mecha_parts/mecha_equipment/tool/extinguisher,/obj/machinery/door_control{desc = "A remote control-switch for the cargo bay doors."; id = "syndieshutters_telebay"; name = "Cargo Bay control"; pixel_x = 0; pixel_y = 25; req_access_txt = "103"},/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"bC" = (/obj/structure/table,/obj/item/weapon/cautery,/obj/item/weapon/hemostat,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bD" = (/obj/machinery/optable,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bE" = (/obj/structure/table,/obj/item/stack/medical/advanced/bruise_pack,/obj/item/weapon/retractor,/turf/simulated/shuttle/floor{icon_state = "floor3"},/area/adminprep/valansship)
+"bF" = (/obj/mecha/medical/odysseus/loaded,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"bG" = (/obj/mecha/working/ripley/firefighter,/turf/simulated/shuttle/floor{icon_state = "floor6"},/area/adminprep/valansship)
+"bH" = (/obj/structure/shuttle/engine/heater,/obj/structure/window/reinforced{dir = 1},/turf/simulated/floor/plating/airless,/area/adminprep/valansship)
+"bI" = (/obj/structure/shuttle/engine/propulsion,/turf/space,/area/adminprep/valansship)
+"bJ" = (/obj/structure/table,/obj/item/weapon/airlock_electronics,/obj/item/weapon/airlock_electronics,/obj/item/weapon/airlock_electronics,/obj/item/weapon/storage/belt/utility/full,/obj/item/weapon/cell/infinite,/obj/item/weapon/cell/infinite,/obj/item/weapon/cell/infinite,/obj/item/stack/cable_coil/yellow,/obj/item/stack/rods{amount = 50},/obj/item/stack/sheet/glass{amount = 50},/obj/item/stack/sheet/metal{amount = 50},/obj/item/device/radio/headset,/obj/item/device/radio/headset,/obj/item/device/radio/headset,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"bK" = (/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"bL" = (/obj/item/device/megaphone,/obj/item/device/megaphone,/obj/item/device/megaphone,/obj/item/weapon/tank/emergency_oxygen/double,/obj/item/weapon/tank/emergency_oxygen/double,/obj/item/weapon/tank/emergency_oxygen/double,/obj/item/clothing/mask/gas,/obj/item/clothing/mask/gas,/obj/item/clothing/mask/gas,/obj/structure/table,/obj/structure/mirror{dir = 4; pixel_x = 0; pixel_y = 28},/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"bM" = (/obj/machinery/portable_atmospherics/canister/oxygen,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"bN" = (/obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse,/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack/explosive,/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg,/obj/item/mecha_parts/mecha_equipment/tool/passenger,/obj/item/mecha_parts/mecha_equipment/tool/rcd,/obj/item/mecha_parts/mecha_equipment/tool/hydraulic_clamp,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"bO" = (/obj/mecha/working/hoverpod,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"bP" = (/obj/mecha/combat/phazon,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"bQ" = (/obj/item/weapon/card/id/centcom{desc = "Visitors ID"; icon = 'icons/obj/vehicles.dmi'; icon_state = "keys"; name = "\improper Visitor. ID"},/obj/item/clothing/shoes/black,/obj/item/device/radio/headset,/obj/item/clothing/glasses/eyepatch/fluff/thysse_1,/obj/item/weapon/storage/backpack/satchel,/obj/item/clothing/under/det/slob,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"bR" = (/obj/machinery/light{dir = 8},/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"bS" = (/obj/machinery/light{dir = 4},/obj/machinery/power/fractal_reactor,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"bT" = (/obj/machinery/floodlight{in_use = 0; on = 1},/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"bU" = (/obj/structure/closet/cabinet,/obj/item/weapon/tank/oxygen,/obj/item/weapon/tank/oxygen,/obj/item/weapon/gun/launcher/pneumatic,/obj/item/weapon/gun/launcher/pneumatic,/obj/item/weapon/gun/launcher/crossbow,/obj/item/weapon/gun/launcher/crossbow,/obj/item/stack/rods{amount = 10},/obj/item/stack/rods{amount = 10},/obj/item/weapon/cell/high,/obj/item/weapon/cell/high,/obj/item/weapon/melee/energy/sword/pirate,/obj/item/weapon/melee/energy/sword/pirate,/obj/item/weapon/gun/projectile/pistol,/obj/item/ammo_magazine/c9mm,/obj/item/weapon/legcuffs/beartrap,/obj/item/weapon/legcuffs/beartrap,/obj/item/weapon/storage/box/handcuffs,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"bV" = (/obj/structure/stool/bed/chair/comfy/black{dir = 8},/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"bW" = (/obj/item/weapon/card/id/captains_spare,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"bX" = (/obj/machinery/door/airlock/external,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"bY" = (/obj/machinery/door/airlock/diamond{req_access_txt = "103"},/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"bZ" = (/obj/machinery/artifact,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"ca" = (/obj/structure/table,/obj/item/weapon/implantcase/explosive,/obj/item/weapon/implantcase/tracking,/obj/item/weapon/implanter,/obj/item/weapon/implanter/explosive,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
+"cb" = (/obj/machinery/computer/card,/obj/machinery/light,/turf/unsimulated/floor{icon_state = "vault"; dir = 8},/area/adminprep/valanspreparea)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -130,43 +113,43 @@ aaabaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaabaaaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacaaabaa
 aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
 aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaaaadaeafafafagahaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaadaiajakalakamaiahaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaanaoapaqaqaqapakanaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaaiarapapapapasakaiaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaaiatapapauapapavaiaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaawaiaxaiaiaiaiaiayaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiazapaAaBaCaiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiapapapapapanaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaadaiapapapapapaiahaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaaadaiaiaiaiaDapapapapaiaiaiaiahaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaaaiaEaFaGaiapapapapapapaHaIaJaKaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaaanaLaMaFaiapapapapapaNaOaPapaKaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaaaiaiaQaRaiapapaSapapapaTaiaUaiaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaaaiaVapapapapaWaXaYapapapapaZaiaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaaaibaapbbapapapbcapapapapapapaiaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaaaibdapbeapapapapapapapbfbgbhaiaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaadaiaiaiaiaiaiaxaiaiaiaiaiaiaiaiahaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaibibjbkblbmaiapaAbnaiapapapapapboaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaabpbqbqbqbqbqaiapapapaiapapapapapboaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaabrbsbtbqbqbqbuapapapaiapapapapapboaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaabvbqbqbqbqbqbuapapbwaiapapapapapboaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaibxbqbqbqbyaiaxbzbAaiapapapapapboaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaibBbCbDbEbFaiapapbGaPaRaiaiaiaiaiaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaibHbqbIbJaiaiapbKbLaiaiaibMbMbMaiaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaibNbObPaiaaaibQbQbQaiaaaibRbRbRaiaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaibQbQbQaiaaawbSbTbUayaaaibQbQbQaiaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaawbSbTbUayaaaaaaaaaaaaaaawbSbTbUayaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaadaiajakalakajaiahaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaamanajajaoajajajamaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaaiapajajajajaqaraiaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaaiasajajatajajauaiaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaavaiawaiaiaiaiaiaxaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiayajazaAaBaiaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaiajajajajajamaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaadaiajajajajajaiahaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaaadaiaiaiaiaCajajajajaiaiaiaiahaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaaaiaDaEaFaiajajajajajajaGaHaIaJaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaaamaEaEaEaiajajajajajaKaLaMajaJaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaaaiaiaiaNaiajajaOajajajaPaiaQaiaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaaaiaRajajajajaSaTaUajajajajaVaiaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaaaiaWajajajajajaXajajajajajajaiaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaaaiaYajaZajajajajajajajajbabbaiaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaadaiaiaiaiaiaiawaiaiaiaiaiaiaiaiahaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaibcbdbebfbgaiajazbhaiajajajajajbiaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaabjaEaEaEaEaEaiajajajaiajajajajajbiaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaabjbkblaEaEaEbmajajajaiajajajajajbiaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaabjaEaEaEaEaEbmajajbnaiajajajajajbiaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaiboaEaEaEbpaiajajbqaiajajajajajbiaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaibrbsbtbubvaiawbwbxaMaNaiaiaiaiaiaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaibyaEbzbAaiaiajajbBaiaiaiajajajaiaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaibCbDbEaiaaaibFajbGaiaaaiajajajaiaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaibHbHbHaiaaavaiafaiaxaaaibHbHbHaiaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaavbIbIbIaxaaaaaaaaaaaaaaavbIbIbIaxaaaaaaaaaaaaaaaaaaaaacaaabaa
 aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
 aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
 aaabaaaaacaaaaaaaaaaaaaaaaaaacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaacbVbWbXbYbZcaacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaccbcccccdcdceacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaccfcfcfcgcdcdacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaacchcicicicdcjacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaccdcdcdcdcdckacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaacclcdcdcdcdcmacaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaccdcdcdcncdcoacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaccpacaaaaacaaabaa
-aaabaaaaacaaaaaaaaaaaaaaaaaaaccqcdcdcrcscoacaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaacbJbKbLbMbNbOacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaacbKbKbKbKbKbPacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaacbKbKbKbQbKbKacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaacbRbKbKbKbKbSacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaacbKbKbKbKbKbTacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaacbUbKbKbKbKbVacaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaacbKbKbKbWbXbYacaaaaaaaaaaaaaaaaaaaaaaaaaaaaacbZacaaaaacaaabaa
+aaabaaaaacaaaaaaaaaaaaaaaaaaaccabKbKcbbXbYacaaaaaaaaaaaaaaaaaaaaaaaaaaaaacacacaaaaacaaabaa
 aaabaaaaacaaaaaaaaaaaaaaaaaaacacacacacacacacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
 aaabaaaaacaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaacaaabaa
 aaabaaaaacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacacaaabaa


### PR DESCRIPTION
I've created a shuttle controller for Valan's ship and made as many reductions as I can to the ship itself. This now makes Valan's ship and map produce about 66,000 instances when loaded (it was over 100,000 before so quite a saving) I still feel this is high though but can't see any more efficiency gains. I'd like to put in some sort of 'if map is loaded' clause but it doesn't seem to generate any errors in dream daemon when it's not so presume it's ok (famous last words) and there doesn't seem to be a func in byond that tells if a map file is open (#if defined just checked if a variable or object is defined. There are funcs to check for unique turfs but these have process overheads so i'm undecided). maybe if you guys added a section when loading maps to set a variable then we could test for that but at the moment the shuttle code will just sit there unused if the shuttle doesn't exist.

All these changes now mean that the merc ship can be totally left alone and won't be interfered with, as long as it's not flying around at the same time all will be fine (they share the same destinations apart from home bases).

I'm done testing and have removed all the iterations and testing builds I made and this is just the final edition. so hopefully all is well now.

On a side note I've found a way of editing the shuttle controller to add new destinations so if someone makes a map with an area defined for the shuttle to land in it's pretty easy to add it as as destination for this or the merc shuttle to fly to and can be done in game (not sure about adding an area in game but that my be possible too if you get the dimensions correct or you may squish the ship).
