### PR TITLE
Radstorm Power Spike

### DIFF
--- a/code/modules/events/radiation_storm.dm
+++ b/code/modules/events/radiation_storm.dm
@@ -31,6 +31,8 @@
 	if(postStartTicks == radIntervall)
 		postStartTicks = 0
 		radiate()
+		for(var/obj/machinery/power/rad_collector/R in rad_collectors)
+			R.receive_pulse(200)
 
 	else if(activeFor == leaveBelt)
 		command_announcement.Announce("The station has passed the radiation belt. Please report to medbay if you experience any unusual symptoms. Maintenance will lose all access again shortly.", "Anomaly Alert")


### PR DESCRIPTION
Radiation storms will cause power spikes, resulting in about 200 KW per filled collector.
