### PR TITLE
Overhaul of the logs

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -22,10 +22,9 @@ var/global/datum/global_init/init = new ()
 #define RECOMMENDED_VERSION 501
 /world/New()
 	//logs
-	var/date_string = time2text(world.realtime, "YYYY/MM-Month/DD-Day")
-	href_logfile = file("data/logs/[date_string] hrefs.htm")
-	diary = file("data/logs/[date_string].log")
-	diary << "[log_end]\n[log_end]\nStarting up. [time2text(world.timeofday, "hh:mm.ss")][log_end]\n---------------------[log_end]"
+	href_logfile = file("data/logs/hrefs.htm")
+	diary = file("data/logs/diary.log")
+	diary << "[log_end]\n[log_end]\nStarting up. [time2text(world.timeofday, "YYYY/MM-Month/DD-Day hh:mm:ss")][log_end]\n---------------------[log_end]"
 
 	if(byond_version < RECOMMENDED_VERSION)
 		world.log << "Your server's byond version does not meet the recommended requirements for this server. Please update BYOND"
@@ -37,7 +36,7 @@ var/global/datum/global_init/init = new ()
 		config.server_name += " #[(world.port % 1000) / 100]"
 
 	if(config && config.log_runtime)
-		log = file("data/logs/runtime/[time2text(world.realtime,"YYYY-MM-DD-(hh-mm-ss)")]-runtime.log")
+		log = file("data/logs/runtime.log")
 
 	callHook("startup")
 	//Emergency Fix


### PR DESCRIPTION
By not creating several new log files for each and every world restart, we could avoid problems with logs filling up the HDD, having to remove said logs periodically (to free up space) and make new fancy log tools in an easier way.

One such tool I'm working on is a really simple log parser that will read in runtime errors from a log, filter out any duplicate errors and present the condensed results on a web page.
It would be a lot easier to work with the logs if there was only a specific set amount of them, with standarized file paths.

On the other hand, by not keeping the old logs it will result in a bunch of other problems. For example, we can't point a web server to the log dir and serve up a complete archive of logs in a quick and easy way. We would have to do some extra job to set up proper log archiving and storage.
But more reason to setup proper log handling I guess.

TODO
- [ ] Make sure the server will overwrite the logs on round start (so they don't keep growing over time).
- [ ] Make sure the relevant verbs (getruntimelogs etc.) still work with the logs.
- [ ] Show off the log parser.

BUGS
- [ ] Last minute runtimes will be lost upon world reset, which will be gone forever.
