### PR TITLE
allow weapon/kitchenknife to cut potatoes

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3006,7 +3006,7 @@
 
 // potato + knife = raw sticks
 /obj/item/weapon/reagent_containers/food/snacks/grown/potato/attackby(obj/item/weapon/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/weapon/kitchen/utensil/knife))
+	if(istype(W,/obj/item/weapon/kitchenknife))
 		new /obj/item/weapon/reagent_containers/food/snacks/rawsticks(src)
 		user << "You cut the potato."
 		qdel(src)


### PR DESCRIPTION
There seems to be 2 different types of knifes. The one we use in the
kitchen is weapon/kitchenknife and the dispenser dispenses them to.
Here in the code though it's looking for a different knife to cut potatoes.

This pull changes what knife potatoes are cut with.

This is just a suggestion, please read the following for more detail:
https://github.com/Apollo-Community/ApolloStation/issues/432
