### PR TITLE
Fix crew transfer vote

### DIFF
--- a/code/controllers/autotransfer.dm
+++ b/code/controllers/autotransfer.dm
@@ -12,6 +12,6 @@ datum/controller/transfer_controller/Destroy()
 
 datum/controller/transfer_controller/proc/process()
 	currenttick = currenttick + 1
-	if (world.time >= timerbuffer - 600)
+	if (world.time >= timerbuffer - 600 && !emergency_shuttle.online())
 		vote.autotransfer()
 		timerbuffer = timerbuffer + config.vote_autotransfer_interval


### PR DESCRIPTION
The server won't call crew transfer votes unless the shuttle is idle at CentComm now. Guess that means it can still call votes during round end, though.
