### PR TITLE
Merc/vox shuttle areas fix

### DIFF
--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -327,6 +327,7 @@ area/space/atmosalert()
 /area/shuttle/syndicate_elite/mothership
 	name = "\improper Merc Elite Shuttle"
 	icon_state = "shuttlered"
+	lighting_use_dynamic = 0
 
 /area/shuttle/syndicate_elite/station
 	name = "\improper Merc Elite Shuttle"
@@ -382,7 +383,8 @@ area/space/atmosalert()
 	name = "\improper Vox Skipjack"
 	icon_state = "yellow"
 	requires_power = 0
-	
+	lighting_use_dynamic = 0
+
 
 /area/shuttle/laborcamp/station
 	name = "\improper Labor Camp Shuttle"

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -382,6 +382,7 @@ area/space/atmosalert()
 	name = "\improper Vox Skipjack"
 	icon_state = "yellow"
 	requires_power = 0
+	
 
 /area/shuttle/laborcamp/station
 	name = "\improper Labor Camp Shuttle"
@@ -452,6 +453,7 @@ area/space/atmosalert()
 	name = "\improper Mercenary Base"
 	icon_state = "syndie-ship"
 	requires_power = 0
+	lighting_use_dynamic = 0
 
 /area/syndicate_mothership/control
 	name = "\improper Mercenary Control Room"
@@ -520,6 +522,7 @@ area/space/atmosalert()
 	icon_state = "yellow"
 	requires_power = 0
 	rad_shielded = 1
+	lighting_use_dynamic = 0
 
 /area/syndicate_station/start
 	name = "\improper Mercenary Forward Operating Base"
@@ -571,6 +574,7 @@ area/space/atmosalert()
 /area/vox_station
 	requires_power = 0
 	rad_shielded = 1
+	lighting_use_dynamic = 0
 
 /area/vox_station/transit
 	name = "\improper bluespace"


### PR DESCRIPTION
The Merc and Vox Shuttle and stations don't have any lights in them, so this is an area fix so that those areas are now fully lit. (I've not done the wizard one) 
This also fixes the areas that are around the station in the shuttles landing zones.

An alternative is that I just add lights to the various shuttles and we run with the existing dynamic lights (which are visually more appealing I must say). Let me know if you'd want me to do that instead of this.

Note: I couldn't test the Vox ship as it's console didn't open for me but the the merc shuttle zones worked fine with Valan's.
