### PR TITLE
Burn_skin

### DIFF
--- a/code/ZAS/Phoron.dm
+++ b/code/ZAS/Phoron.dm
@@ -93,7 +93,7 @@ obj/var/contaminated = 0
 	//Burn skin if exposed.
 	if(vsc.plc.SKIN_BURNS)
 		if(!pl_head_protected() || !pl_suit_protected())
-			burn_skin(.75)
+			burn_skin(0.75)
 			if(prob(20)) src << pick( "\red Your skin burns!", "\red You feel your skin peeling away!", "\red Blisters begin to form on your skin!", "\red Your skin is unbearably itchy!" )
 			updatehealth()
 

--- a/code/ZAS/Phoron.dm
+++ b/code/ZAS/Phoron.dm
@@ -93,7 +93,7 @@ obj/var/contaminated = 0
 	//Burn skin if exposed.
 	if(vsc.plc.SKIN_BURNS)
 		if(!pl_head_protected() || !pl_suit_protected())
-			burn_skin(5)
+			burn_skin(.75)
 			if(prob(20)) src << pick( "\red Your skin burns!", "\red You feel your skin peeling away!", "\red Blisters begin to form on your skin!", "\red Your skin is unbearably itchy!" )
 			updatehealth()
 


### PR DESCRIPTION
Reduces damage dealt by Phoron when it comes into contact with skin to bring it up to date with Bay. This should also allow aliens to recover Phoron faster than it is depleted by skin damage. Will be fully fixed with future changes to life.dm

Further in-game testing is required to verify intended effects.
Adjustments made are safe enough for public testing.

I found significant discrepancies between code/modules/mob/living/carbon/alien/life.dm on both the tg and Bay branches. Our codebase utilizes ZAS while tg utilizes Linda, however, bay's and apollo's phoron code for burning skin relies on:

if(vsc.plc.SKIN_BURNS)
        if(!pl_head_protected() || !pl_suit_protected()).
            burn_skin(0.75)
            if(prob(20)) src << "\red Your skin burns!"
            updatehealth()

I am currently researching this to determine a proper fix to resolve the issue for Aliens as pl_suit_protected does not appear to be defined.
