### PR TITLE
Chemistry Dispenser now requires Chemistry access.

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -11,6 +11,7 @@
 	anchored = 1
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "dispenser"
+	req_access = list(access_chemistry)
 	use_power = 1
 	idle_power_usage = 40
 	var/ui_title = "Chem Dispenser 5000"


### PR DESCRIPTION
See title. Non-medical staff should have no knowledge of how Chemistry works, so it only makes sense to lock it to guard against the grey tide if only for roleplay reasons.  

Admin policies to compensate for lack of code is [not okay.](https://apollo-community.org/viewtopic.php?f=34&t=579)
