### PR TITLE
SMES access restricted to Engineers

### DIFF
--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -8,6 +8,7 @@
 /obj/machinery/power/smes
 	name = "power storage unit"
 	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit."
+	req_access = list(access_engine_equip)
 	icon_state = "smes"
 	density = 1
 	anchored = 1

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -8,7 +8,7 @@
 /obj/machinery/power/smes
 	name = "power storage unit"
 	desc = "A high-capacity superconducting magnetic energy storage (SMES) unit."
-	req_access = list(access_engine_equip)
+	req_access = list(access_atmospherics, access_engine_equip)
 	icon_state = "smes"
 	density = 1
 	anchored = 1


### PR DESCRIPTION
See title. For the same reason APCs are access locked, now only the Chief Engineer and Engineers should have knowledge of the function of SMES units and should be the only ones able to change them.
