### PR TITLE
Updates Controllers

### DIFF
--- a/apollo.dme
+++ b/apollo.dme
@@ -197,8 +197,6 @@
 #include "code\controllers\ProcessScheduler\core\_stubs.dm"
 #include "code\controllers\ProcessScheduler\core\process.dm"
 #include "code\controllers\ProcessScheduler\core\processScheduler.dm"
-#include "code\controllers\ProcessScheduler\core\updateQueue.dm"
-#include "code\controllers\ProcessScheduler\core\updateQueueWorker.dm"
 #include "code\controllers\subsystem\cell_auto.dm"
 #include "code\datums\ai_laws.dm"
 #include "code\datums\browser.dm"

--- a/code/controllers/Processes/disease.dm
+++ b/code/controllers/Processes/disease.dm
@@ -1,15 +1,16 @@
 /datum/controller/process/disease
-	var/tmp/datum/updateQueue/updateQueueInstance
 
 /datum/controller/process/disease/setup()
 	name = "disease"
 	schedule_interval = 30 // every 3 seconds
 	cpu_threshold = 20
-	updateQueueInstance = new
 
 /datum/controller/process/disease/doWork()
-	updateQueueInstance.init(active_diseases, "process")
-	updateQueueInstance.Run()
+	for(var/datum/disease/D in active_diseases)
+		if(D)
+			D.process()
+			continue
+		active_diseases.Remove(D)
 
 /datum/controller/process/disease/getStatName()
 	return ..()+"([active_diseases.len])"

--- a/code/controllers/Processes/mob.dm
+++ b/code/controllers/Processes/mob.dm
@@ -1,28 +1,19 @@
 /var/global/datum/controller/process/mob/MobProcess
 
-/datum/controller/process/mob
-	var/tmp/datum/updateQueue/updateQueueInstance
-
 /datum/controller/process/mob/setup()
-	name = "mob"
-	schedule_interval = 20 // every 2 seconds
-	cpu_threshold = 50
-	updateQueueInstance = new
+    name = "mob"
+    schedule_interval = 20 // every 2 seconds
+    cpu_threshold = 50
 
-	MobProcess = src
-
-/datum/controller/process/mob/started()
-	..()
-	if(!updateQueueInstance)
-		if(!mob_list)
-			mob_list = list()
-		else if(mob_list.len)
-			updateQueueInstance = new
+    MobProcess = src
 
 /datum/controller/process/mob/doWork()
-	if(updateQueueInstance)
-		updateQueueInstance.init(mob_list, "Life")
-		updateQueueInstance.Run()
+    for(var/mob/M in mob_list)
+        if(M)
+            M.Life()
+            continue
+        mob_list.Remove(M)
+        scheck()
 
 /datum/controller/process/mob/getStatName()
-	return ..()+"([mob_list.len])"
+    return ..()+"([mob_list.len])"

--- a/code/controllers/Processes/nanoui.dm
+++ b/code/controllers/Processes/nanoui.dm
@@ -1,15 +1,17 @@
 /datum/controller/process/nanoui
-	var/tmp/datum/updateQueue/updateQueueInstance
 
 /datum/controller/process/nanoui/setup()
 	name = "nanoui"
 	schedule_interval = 20 // every 2 second
 	cpu_threshold = 30
-	updateQueueInstance = new
+
 
 /datum/controller/process/nanoui/doWork()
-	updateQueueInstance.init(nanomanager.processing_uis, "process")
-	updateQueueInstance.Run()
+	for(var/datum/nanoui/N in nanomanager.processing_uis)
+		if(N)
+			N.process()
+			continue
+		nanomanager.processing_uis.Remove()
 
 /datum/controller/process/nanoui/getStatName()
 	return ..()+"([nanomanager.processing_uis.len])"

--- a/code/controllers/Processes/obj.dm
+++ b/code/controllers/Processes/obj.dm
@@ -1,29 +1,20 @@
 var/global/list/object_profiling = list()
 /var/global/datum/controller/process/obj/ObjProcess
 
-/datum/controller/process/obj
-	var/tmp/datum/updateQueue/updateQueueInstance
-
 /datum/controller/process/obj/setup()
-	name = "obj"
-	schedule_interval = 40 // every 4 seconds
-	cpu_threshold = 50
-	updateQueueInstance = new
+    name = "obj"
+    schedule_interval = 40 // every 4 seconds
+    cpu_threshold = 50
 
-	ObjProcess = src
-
-/datum/controller/process/obj/started()
-	..()
-	if(!updateQueueInstance)
-		if(!processing_objects)
-			processing_objects = list()
-		else if(processing_objects.len)
-			updateQueueInstance = new
+    ObjProcess = src
 
 /datum/controller/process/obj/doWork()
-	if(updateQueueInstance)
-		updateQueueInstance.init(processing_objects, "process")
-		updateQueueInstance.Run()
+    for(var/obj/O in processing_objects)
+        if(O)
+            O.process()
+            continue
+        processing_objects.Remove(O)
+        scheck()
 
 /datum/controller/process/obj/getStatName()
-	return ..()+"([processing_objects.len])"
+    return ..()+"([processing_objects.len])"


### PR DESCRIPTION
On my local test server completely removes lag spikes caused by machinery processing and brings world.CPU down to 1-2 per tick. 

Removes update queue worker to be replaced by process scheduler.
