### PR TITLE
Added procs for isCrit and isDying

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -583,3 +583,11 @@ proc/is_blind(A)
 
 /mob/proc/is_client_active(var/active = 1)
 	return client && client.inactivity < active MINUTES
+	
+/proc/isCrit(var/mob/living/M)
+    if(M.health < config.health_threshold_softcrit && M.health > config.health_threshold_crit)
+        return 1
+
+/proc/isDying(var/mob/living/M)
+    if(isCrit(M) && M.stat == 1)
+        return 1


### PR DESCRIPTION
The difference between the two is that isCrit just checks for where their health is, while isDying checks if they're both inCrit and unconscious.
