### PR TITLE
Last words implementation

### DIFF
--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -98,9 +98,11 @@
 	if(!client)
 		return
 		
-	if(isDying(src))
-		hear_dying(message,speaker)
-		return
+	if(isDying())   
+    		if(prob(30))
+        		src << "<span class = 'game_say'>...You hear...[lentext(message) > 20 ? "[copytext(message,1,20)]..." : "[message]..."] hiss in your ear.</span>"
+    		else
+        		src << "<span class = 'game_say'>...You hear a hiss in your ear...</span>"
 		
 	if(sleeping || stat==1) //If unconscious or sleeping
 		hear_sleep(message)
@@ -256,3 +258,4 @@
 		message = "span class = 'game_say'>...You hear someone say...\"[message]\"</span>"
 	else
 		message = "<span class = 'game_say'>...<i>You almost hear someone talking</i>...</span>"
+	src << message

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -24,7 +24,10 @@
 	if(sleeping || stat == 1)
 		hear_sleep(message)
 		return
-
+		
+	if(isDying(src))
+		hear_dying(message,speaker)
+		return
 	//non-verbal languages are garbled if you can't see the speaker. Yes, this includes if they are inside a closet.
 	if (language && (language.flags & NONVERBAL))
 		if (!speaker || (src.sdisabilities & BLIND || src.blinded) || !(speaker in view(src)))
@@ -97,7 +100,9 @@
 	if(sleeping || stat==1) //If unconscious or sleeping
 		hear_sleep(message)
 		return
-
+	if(isDying(src))
+		hear_dying(message,speaker)
+		return
 	var/track = null
 
 	//non-verbal languages are garbled if you can't see the speaker. Yes, this includes if they are inside a closet.
@@ -243,3 +248,9 @@
 		heard = "<span class = 'game_say'>...<i>You almost hear someone talking</i>...</span>"
 
 	src << heard
+
+/mob/proc/hear_dying(var/message, var/mob/M)
+	if(get_dist(src, M) <= 2)
+		message = "span class = 'game_say'>...You hear someone say...\"[message]\"</span>"
+	else
+		message = "<span class = 'game_say'>...<i>You almost hear someone talking</i>...</span>"

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -21,13 +21,14 @@
 			italics = 1
 			sound_vol *= 0.5 //muffle the sound a bit, so it's like we're actually talking through contact
 
-	if(sleeping || stat == 1)
-		hear_sleep(message)
-		return
-		
 	if(isDying(src))
 		hear_dying(message,speaker)
 		return
+		
+	if(sleeping || stat == 1)
+		hear_sleep(message)
+		return
+
 	//non-verbal languages are garbled if you can't see the speaker. Yes, this includes if they are inside a closet.
 	if (language && (language.flags & NONVERBAL))
 		if (!speaker || (src.sdisabilities & BLIND || src.blinded) || !(speaker in view(src)))
@@ -96,12 +97,13 @@
 
 	if(!client)
 		return
-
-	if(sleeping || stat==1) //If unconscious or sleeping
-		hear_sleep(message)
-		return
+		
 	if(isDying(src))
 		hear_dying(message,speaker)
+		return
+		
+	if(sleeping || stat==1) //If unconscious or sleeping
+		hear_sleep(message)
 		return
 	var/track = null
 

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -98,11 +98,11 @@
 	if(!client)
 		return
 		
-	if(isDying())   
-    		if(prob(30))
-        		src << "<span class = 'game_say'>...You hear...[lentext(message) > 20 ? "[copytext(message,1,20)]..." : "[message]..."] hiss in your ear.</span>"
-    		else
-        		src << "<span class = 'game_say'>...You hear a hiss in your ear...</span>"
+	if(isDying(src))   
+		if(prob(30))
+			src << "<span class = 'game_say'>...You hear...[lentext(message) > 20 ? "[copytext(message,1,20)]..." : "[message]..."] hiss in your ear.</span>"
+		else
+			src << "<span class = 'game_say'>...You hear a hiss in your ear...</span>"
 		
 	if(sleeping || stat==1) //If unconscious or sleeping
 		hear_sleep(message)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -41,12 +41,19 @@
 	usr.visible_message("<b>[src]</b> points to [A]")
 	return 1
 
+//Last words.
 /mob/living/verb/succumb()
-	set hidden = 1
-	if ((src.health < 0 && src.health > -95.0))
-		src.adjustOxyLoss(src.health + 200)
-		src.health = 100 - src.getOxyLoss() - src.getToxLoss() - src.getFireLoss() - src.getBruteLoss()
-		src << "<span class='notice'>You have given up life and succumbed to death.</span>"
+    set hidden = 1
+    if ((src.health < 0 && src.health > -95.0))
+        src.adjustOxyLoss(src.health + 200)
+        src.health = 100 - src.getOxyLoss() - src.getToxLoss() - src.getFireLoss() - src.getBruteLoss()
+        src << "<span class='notice'>You have given up life and succumbed to death.</span>"
+
+/mob/living/carbon/human/succumb()
+    if(isDying())
+        var/input = input(src,"What are your final words?", "Final Words")
+        whisper(lentext(input) > 20 ? "[copytext(input,1,20)]..." : "[input]...")
+        ..()
 
 
 /mob/living/proc/updatehealth()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -44,7 +44,7 @@
 //Last words.
 /mob/living/verb/succumb()
     set hidden = 1
-    if ((src.health < 0 && src.health > -95.0))
+    if (isCrit())
         src.adjustOxyLoss(src.health + 200)
         src.health = 100 - src.getOxyLoss() - src.getToxLoss() - src.getFireLoss() - src.getBruteLoss()
         src << "<span class='notice'>You have given up life and succumbed to death.</span>"

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -583,3 +583,11 @@ proc/is_blind(A)
 
 /mob/proc/is_client_active(var/active = 1)
 	return client && client.inactivity < active MINUTES
+	
+/proc/isCrit(var/mob/living/M)
+    if(M.health < config.health_threshold_softcrit && M.health > config.health_threshold_crit)
+        return 1
+
+/proc/isDying(var/mob/living/M)
+    if(isCrit(M) && M.stat == 1)
+        return 1


### PR DESCRIPTION
Referencing my own suggestion here: #606 
When in critical condition and close to death, players can now hear mobs in Whisper distance of them, along with the ability to whisper their own last words before succumbing to death.

**Thanks to Stuicey and Kwask for their patience in teaching me this!**
- [X] New procs for Crit/Dying
- [ ] Ability to hear others within whispering distance
- [X] Ability to whisper last words after succumbing
- [ ] Can either hear bits of radio messages, or none at all.
- [ ] Users can hear (see) how their message sent after death.
  Anything else needs testing.

Please don't merge yet, as this hasn't been tested in-game
