### PR TITLE
Soda & Booze dispenser unanchoring

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -231,6 +231,13 @@ obj/machinery/chem_dispenser/RefreshParts()
 			dispensable_reagents -= list("thirteenloko","grapesoda")
 			hackedcheck = 0
 			return
+	if(istype(B, /obj/item/weapon/wrench))
+		if(anchored)
+			user << "<span class='notice'>You unfasten [src].</span>"
+			anchored = 0
+		else
+			user << "<span class='notice'>You wrench down [src].</span>"
+			anchored = 1
 
 /obj/machinery/chem_dispenser/beer
 	icon_state = "booze_dispenser"
@@ -257,6 +264,13 @@ obj/machinery/chem_dispenser/RefreshParts()
 			dispensable_reagents -= list("goldschlager","patron","watermelonjuice","berryjuice")
 			hackedcheck = 0
 			return
+	if(istype(B, /obj/item/weapon/wrench))
+		if(anchored)
+			user << "<span class='notice'>You unfasten [src].</span>"
+			anchored = 0
+		else
+			user << "<span class='notice'>You wrench down [src].</span>"
+			anchored = 1
 
 /obj/machinery/chem_dispenser/meds
 	name = "chem dispenser magic"

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -205,6 +205,8 @@ obj/machinery/chem_dispenser/RefreshParts()
 /obj/machinery/chem_dispenser/attack_hand(mob/user as mob)
 	if(stat & BROKEN)
 		return
+	if(!anchored)
+		user << "<span class='warning'>[src] is unsecured and unable to be used.</span>"
 	ui_interact(user)
 
 /obj/machinery/chem_dispenser/soda


### PR DESCRIPTION
Soda and booze dispensers can now be anchored and unanchored with a wrench.
#623
