### PR TITLE
Table Placement Pixel Positioning

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -112,7 +112,7 @@
 			if(W.flags&USEDELAY)
 				next_move += 5
 
-			var/resolved = A.attackby(W,src)
+			var/resolved = A.attackby(W,src,params)
 			if(!resolved && A && W)
 				W.afterattack(A,src,1,params) // 1 indicates adjacency
 		else
@@ -133,7 +133,7 @@
 					next_move += 5
 
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
-				var/resolved = A.attackby(W,src)
+				var/resolved = A.attackby(W,src,params)
 				if(!resolved && A && W)
 					W.afterattack(A,src,1,params) // 1: clicking something Adjacent
 			else

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -4,7 +4,7 @@
 	return
 
 // No comment
-/atom/proc/attackby(obj/item/W, mob/user)
+/atom/proc/attackby(obj/item/W, mob/user, params)
 	return
 
 /atom/movable/attackby(obj/item/W, mob/user)

--- a/code/modules/reagents/reagent_containers/food.dm
+++ b/code/modules/reagents/reagent_containers/food.dm
@@ -1,5 +1,7 @@
+/*
 #define CELLS 4
 #define CELLSIZE (32/CELLS)
+*/
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Food.
@@ -17,6 +19,8 @@
 		src.pixel_x = rand(-6.0, 6) //Randomizes postion
 		src.pixel_y = rand(-6.0, 6)
 
+//Made obsolete thanks to table pixel placement for all items.
+/*
 /obj/item/weapon/reagent_containers/food/afterattack(atom/A, mob/user, proximity, params)
 	if(proximity && params && istype(A, /obj/structure/table) && center_of_mass.len)
 		//Places the item on a grid
@@ -36,3 +40,4 @@
 
 #undef CELLS
 #undef CELLSIZE
+*/


### PR DESCRIPTION
Ports table pixel positioning from /tg/. Centers the item's icon to the pixel where the table was clicked.
The food.dm change was due to foods having this feature before but now all items do so it's unnecessary now.
