### PR TITLE
Fix for "infinite packages"

### DIFF
--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -266,6 +266,7 @@
 					if(3) P.name = "normal-sized parcel"
 					if(4) P.name = "large parcel"
 					if(5) P.name = "huge parcel"
+				O.forceMove(P)
 
 				P.add_fingerprint(usr)
 				O.add_fingerprint(usr)


### PR DESCRIPTION
Wrapping up objects was broken, you would wrap a package and the item would stay where it was and not get relocated to inside the package. This fixes that.
Fix for #1064
