### PR TITLE
Fix for inability to add chem access

### DIFF
--- a/code/game/jobs/departments.dm
+++ b/code/game/jobs/departments.dm
@@ -83,7 +83,7 @@
 	department_id = SCIENCE
 	background_color = "#ffeeff"
 	starting_positions = list( "Research Assistant" = "High" )
-	region_access = list(access_research, access_tox, access_moon, access_robotics, access_xenobiology, access_xenoarch, access_rd, access_tcomsat)
+	region_access = list(access_research, access_tox, access_chemistry, access_moon, access_robotics, access_xenobiology, access_xenoarch, access_rd, access_tcomsat)
 
 /datum/department/security
 	name = "Security Department"


### PR DESCRIPTION
You can now add chem access to ID cards properly.
Fix for #1034
