### PR TITLE
Phoron Glass Bugfix 2: Electric Boogaloo

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -185,7 +185,6 @@
 	created_window = /obj/structure/window/phoronbasic
 
 /obj/item/stack/sheet/glass/phoronglass/attackby(obj/item/W, mob/user)
-	..()
 	if( istype(W, /obj/item/stack/rods) )
 		var/obj/item/stack/rods/V  = W
 		var/obj/item/stack/sheet/glass/phoronglass/reinforced/RG = new (user.loc)


### PR DESCRIPTION
I overlooked a bug where making reinforced phoron glass made normal reinforced glass along with reinforced phoron glass. Fixed now.
