### PR TITLE
Evidence Bag TG Port

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -215,6 +215,24 @@ world
 
 #define TO_HEX_DIGIT(n) ascii2text((n&15) + ((n&15)<10 ? 48 : 87))
 
+/atom/proc/add_overlay(image, priority = 0)
+	if(image in overlays)
+		return
+	var/list/new_overlays = overlays.Copy()
+	if(priority)
+		if(!priority_overlays)
+			priority_overlays = list()
+		priority_overlays += image
+		new_overlays += image
+	else
+		if(priority_overlays)
+			new_overlays -= priority_overlays
+			new_overlays += image
+			new_overlays += priority_overlays
+		else
+			new_overlays += image
+	overlays = new_overlays
+
 icon
 	proc/MakeLying()
 		var/icon/I = new(src,dir=SOUTH)

--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -949,21 +949,3 @@ proc/sort_atoms_by_layer(var/list/atoms)
 /atom/proc/cut_overlays()
 	overlays.Cut()
 	overlays += priority_overlays
-
-/atom/proc/add_overlay(image, priority = 0)
-	if(image in overlays)
-		return
-	var/list/new_overlays = overlays.Copy()
-	if(priority)
-		if(!priority_overlays)
-			priority_overlays = list()
-		priority_overlays += image
-		new_overlays += image
-	else
-		if(priority_overlays)
-			new_overlays -= priority_overlays
-			new_overlays += image
-			new_overlays += priority_overlays
-		else
-			new_overlays += image
-	overlays = new_overlays

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -24,6 +24,9 @@
 	//Detective Work, used for the duplicate data points kept in the scanners
 	var/list/original_atom
 
+	//overlays that should remain on top and not normally be removed, like c4.
+	var/list/priority_overlays
+
 /atom/proc/assume_air(datum/gas_mixture/giver)
 	return null
 

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -10,18 +10,20 @@
 	var/obj/item/stored_item = null
 
 /obj/item/weapon/evidencebag/afterattack(obj/item/I, mob/user,proximity)
+	if(!istype(I) || I.anchored == 1)
+		return
+	switch(alert(user,"Do you want to try to put [I] into [src]?","Evidence bag","Yes","No"))
+		if("No")
+			return
 	if(!proximity || loc == I)
 		return
 	evidencebagEquip(I, user)
 
 /obj/item/weapon/evidencebag/attackby(obj/item/I, mob/user, params)
-	if(evidencebagEquip(I, user))
+	if(evidencebagEquip(I, user,))
 		return 1
 
-/obj/item/weapon/evidencebag/proc/evidencebagEquip(obj/item/I, mob/user)
-	if(!istype(I) || I.anchored == 1)
-		return
-
+/obj/item/weapon/evidencebag/proc/evidencebagEquip(obj/item/I, mob/user, bagattack = 1)
 	if(istype(I, /obj/item/weapon/evidencebag))
 		user << "<span class='notice'>You find putting an evidence bag in another evidence bag to be slightly absurd.</span>"
 		return 1 //now this is podracing
@@ -45,9 +47,18 @@
 		else
 			return
 
-	switch(alert(user,"Do you want to put [I] into [src]?","Evidence bag","Yes","No"))
-		if("No")
+	if (!(user.l_hand == src || user.r_hand == src))
+		return //bag must be in your hands to use
+
+	if (isturf(I.loc))
+		if (!user.Adjacent(I))
 			return
+	else
+		//If it isn't on the floor. Do some checks to see if it's in our hands or a box. Otherwise give up.
+		if(istype(I.loc,/obj/item/weapon/storage))	//in a container.
+			var/sdepth = I.storage_depth(user)
+			if (sdepth == -1 || sdepth > 1)
+				return	//too deeply nested to access
 
 	user.visible_message("[user] puts [I] into [src].", "<span class='notice'>You put [I] inside [src].</span>",\
 	"<span class='italics'>You hear a rustle as someone puts something into a plastic bag.</span>")

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -9,41 +9,22 @@
 	w_class = 2
 	var/obj/item/stored_item = null
 
-/obj/item/weapon/evidencebag/MouseDrop(var/obj/item/I as obj)
-	if (!ishuman(usr))
+/obj/item/weapon/evidencebag/afterattack(obj/item/I, mob/user,proximity)
+	if(!proximity || loc == I)
 		return
+	evidencebagEquip(I, user)
 
-	var/mob/living/carbon/human/user = usr
+/obj/item/weapon/evidencebag/attackby(obj/item/I, mob/user, params)
+	if(evidencebagEquip(I, user))
+		return 1
 
-	if (!(user.l_hand == src || user.r_hand == src))
-		return //bag must be in your hands to use
-
-	if (isturf(I.loc))
-		if (!user.Adjacent(I))
-			return
-	else
-		//If it isn't on the floor. Do some checks to see if it's in our hands or a box. Otherwise give up.
-		if(istype(I.loc,/obj/item/weapon/storage))	//in a container.
-			var/sdepth = I.storage_depth(user)
-			if (sdepth == -1 || sdepth > 1)
-				return	//too deeply nested to access
-
-			var/obj/item/weapon/storage/U = I.loc
-			user.client.screen -= I
-			U.contents.Remove(I)
-		else if(user.l_hand == I)					//in a hand
-			user.drop_l_hand()
-		else if(user.r_hand == I)					//in a hand
-			user.drop_r_hand()
-		else
-			return
-
-	if(!istype(I) || I.anchored)
+/obj/item/weapon/evidencebag/proc/evidencebagEquip(obj/item/I, mob/user)
+	if(!istype(I) || I.anchored == 1)
 		return
 
 	if(istype(I, /obj/item/weapon/evidencebag))
 		user << "<span class='notice'>You find putting an evidence bag in another evidence bag to be slightly absurd.</span>"
-		return
+		return 1 //now this is podracing
 
 	if(I.w_class > 3)
 		user << "<span class='notice'>[I] won't fit in [src].</span>"
@@ -53,8 +34,19 @@
 		user << "<span class='notice'>[src] already has something inside it.</span>"
 		return
 
-	user.visible_message("[user] puts [I] into [src]", "You put [I] inside [src].",\
-	"You hear a rustle as someone puts something into a plastic bag.")
+	if(!isturf(I.loc)) //If it isn't on the floor. Do some checks to see if it's in our hands or a box. Otherwise give up.
+		if(istype(I.loc,/obj/item/weapon/storage))	//in a container.
+			var/obj/item/weapon/storage/U = I.loc
+			U.remove_from_storage(I, src)
+		else if(user.l_hand == I)					//in a hand
+			user.drop_l_hand()
+		else if(user.r_hand == I)					//in a hand
+			user.drop_r_hand()
+		else
+			return
+
+	user.visible_message("[user] puts [I] into [src].", "<span class='notice'>You put [I] inside [src].</span>",\
+	"<span class='italics'>You hear a rustle as someone puts something into a plastic bag.</span>")
 
 	icon_state = "evidence"
 
@@ -65,14 +57,13 @@
 	var/image/img = image("icon"=I, "layer"=FLOAT_LAYER)	//take a snapshot. (necessary to stop the underlays appearing under our inventory-HUD slots ~Carn
 	I.pixel_x = xx		//and then return it
 	I.pixel_y = yy
-	overlays += img
-	overlays += "evidence"	//should look nicer for transparent stuff. not really that important, but hey.
+	add_overlay(img)
+	add_overlay("evidence")	//should look nicer for transparent stuff. not really that important, but hey.
 
-	desc = "An evidence bag containing [I]."
+	desc = "An evidence bag containing [I]. [I.desc]"
 	I.loc = src
-	stored_item = I
 	w_class = I.w_class
-	return
+	return 1
 
 
 /obj/item/weapon/evidencebag/attack_self(mob/user as mob)

--- a/code/modules/detectivework/evidence.dm
+++ b/code/modules/detectivework/evidence.dm
@@ -45,6 +45,10 @@
 		else
 			return
 
+	switch(alert(user,"Do you want to put [I] into [src]?","Evidence bag","Yes","No"))
+		if("No")
+			return
+
 	user.visible_message("[user] puts [I] into [src].", "<span class='notice'>You put [I] inside [src].</span>",\
 	"<span class='italics'>You hear a rustle as someone puts something into a plastic bag.</span>")
 


### PR DESCRIPTION
Evidence bags now work on the attackby proc instead of relying on drag-and-drop. This is what other servers are doing, so this will prevent new players getting confused with how to use them.
You can use an object on the evidence bag or the evidence bag or an object to contain it.
They also have a confirmation window so you don't stuff something you don't want to. Attacking the evidence bag with an item however doesn't give one since it seems more deliberate.

This also SHOULD fix #994
