### PR TITLE
fixed the headset uplink

### DIFF
--- a/code/modules/antagonist/antagonists/traitor.dm
+++ b/code/modules/antagonist/antagonists/traitor.dm
@@ -40,6 +40,8 @@
 		var/freq = rand(1441, 1489)
 		while(freq in radiochannels)
 			freq = rand(1441, 1489)
+		if ((freq % 2) == 0)
+			freq += 1
 
 		var/obj/item/device/uplink/hidden/T = new(I)
 		T.uplink_owner = antag


### PR DESCRIPTION
traitor headset uplinks might be set to even numbers radios can only be set to odd numbers. Now its fixed.
