### PR TITLE
Fixes the violin

### DIFF
--- a/code/game/objects/items/devices/violin.dm
+++ b/code/game/objects/items/devices/violin.dm
@@ -13,12 +13,11 @@
 	var/edit = 1
 	var/repeat = 0
 
-/obj/item/device/violin/proc/playnote(var/note as text)
+/obj/item/device/violin/proc/playnote(var/note as text, mob/living/user as mob|obj)
 	if(!note)	return
 	var/soundfile = "sound/violin/[note].mid"
 
-	for(var/mob/M in ohearers(7, src))
-		M.playsound_local(src, file(soundfile), 100, falloff = 5)
+	hearers(7, get_turf(src)) << sound(soundfile)
 
 /obj/item/device/violin/proc/playsong()
 	do


### PR DESCRIPTION
Violin code was piano code copy and pasted, however piano code checks the obj's coords and plays the sounds there. When a violin is in someone's inventory, the coors are set to (0,0,0), which is why you wouldn't here music being played. Changed the play proc to search for the turf the violin was located on and play from there.